### PR TITLE
Fix the issue with parsing the incorrect return status

### DIFF
--- a/jqdatapy/api.py
+++ b/jqdatapy/api.py
@@ -318,7 +318,7 @@ def _get_token(mob=None, pwd=None):
     }
     response = requests.post(url, data=json.dumps(body))
 
-    if response.status_code != 200:
+    if response.status_code != 200 or response.text.startswith("error"):
         print(f"request jqdata error,code:{response.status_code},text:{response.text}")
         raise HttpAccessError(code=response.status_code, msg=response.text)
 
@@ -329,7 +329,7 @@ def _request_jqdata(method: string, token: string = jqdata_env["token"], **kwarg
     body = {"method": method, "token": token, **kwargs}
     response = jqdata_session.post(url, data=json.dumps(body))
 
-    if response.status_code != 200:
+    if response.status_code != 200 or response.text.startswith("error"):
         print(f"request jqdata error,code:{response.status_code},text:{response.text}")
         raise HttpAccessError(code=response.status_code, msg=response.text)
 


### PR DESCRIPTION
origin：
![image](https://github.com/user-attachments/assets/a28476b4-d17a-4cbf-86d3-00d1192af623)
I used ZVT to retrieve financial data from Eastmoney, and then a large number of errors appeared in the console.
These errors are highly unusual.

cause：
![PixPin_2024-08-12_20-44-31](https://github.com/user-attachments/assets/6cc0ed8e-0a85-4284-8810-4b64c9ce20fc)
It appears that the JoinQuant API does not use 'status' to indicate the response status; instead, it starts the returned text with 'error' to indicate an issue.